### PR TITLE
fix: remove internationalization from InputEventKey methods

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -472,9 +472,9 @@ String InputEventKey::as_text() const {
 	} else if (keycode != Key::NONE) {
 		kc = keycode_get_string(keycode);
 	} else if (physical_keycode != Key::NONE) {
-		kc = keycode_get_string(physical_keycode) + " (" + RTR("Physical") + ")";
+		kc = keycode_get_string(physical_keycode) + " (Physical)";
 	} else {
-		kc = "(" + RTR("Unset") + ")";
+		kc = "(Unset)";
 	}
 
 	if (kc.is_empty()) {
@@ -505,7 +505,7 @@ String InputEventKey::to_string() {
 		kc = itos((int64_t)physical_keycode) + " (" + keycode_get_string(physical_keycode) + ")";
 		physical = "true";
 	} else {
-		kc = "(" + RTR("Unset") + ")";
+		kc = "(Unset)";
 	}
 
 	String mods = InputEventWithModifiers::as_text();


### PR DESCRIPTION
When compiled and executed in a SO with a system language other than english (in this case portuguese), some tests failed because two InputEventKey methods (`as_text` and `to_string`) translated parts of the strings before returning it. To fix this, the internationalization in this methods where removed.

#14