### PR TITLE
Fix remove duplicated exception catch

### DIFF
--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -111,7 +111,7 @@ def find_msbuild_tools_path_reg():
         print("Error reading output from vswhere: " + str(e))
     except OSError:
         pass  # Fine, vswhere not found
-    except (subprocess.CalledProcessError, OSError):
+    except (subprocess.CalledProcessError):
         pass
 
 


### PR DESCRIPTION
The same exception was treated in two consecutive `except`, so the later was removed to reduce duplication.

#14 